### PR TITLE
Fix problem where booleans are converted to strings in pie charts

### DIFF
--- a/src/beaverdam/viewer/presenter.py
+++ b/src/beaverdam/viewer/presenter.py
@@ -109,3 +109,18 @@ class Presenter:
         element_properties = all_elements[element_id]["properties"]
 
         return element_properties
+
+    def get_element_contents(self, element_id):
+        """Get the contents of an element, given the element's id.
+
+        Args:
+            element_id (str):  the unique id of the element
+
+        Returns:
+            element_contents (dict):  properties of the element
+
+        """
+        all_elements = self.get_elements()
+        element_contents = all_elements[element_id]["contents"]
+
+        return element_contents


### PR DESCRIPTION
This fixes #1 by checking the clicked value against the plotted data, if the user clicks on a boolean-like value in a pie chart.

Bar graphs, scatterplots, and box plots don't seem to have this problem, so their code is unchanged.