### PR TITLE
Change imports of beaverdam modules to use absolute paths.

### DIFF
--- a/src/beaverdam/_core/core.py
+++ b/src/beaverdam/_core/core.py
@@ -1,7 +1,7 @@
 """Query databases of metadata and filter the results."""
 
-from .datatablecore import DataTableCore
-from .metadatasource import MongoDbDatabase
+from beaverdam._core.datatablecore import DataTableCore
+from beaverdam._core.metadatasource import MongoDbDatabase
 
 
 class Core:

--- a/src/beaverdam/builder/build_database.py
+++ b/src/beaverdam/builder/build_database.py
@@ -8,8 +8,8 @@ from tqdm import tqdm
 
 from beaverdam._core import ConfigParser, MongoDbDatabase
 
-from .metadatafiletools import load_metadata
-from .pluralize import pluralize
+from beaverdam.builder.metadatafiletools import load_metadata
+from beaverdam.builder.pluralize import pluralize
 
 ## INPUTS
 

--- a/src/beaverdam/viewer/builduielements_dash.py
+++ b/src/beaverdam/viewer/builduielements_dash.py
@@ -12,7 +12,7 @@ from dash import dash_table, dcc, html
 from . import (
     plotly_theme,  # noqa: F401
 )
-from .plotly_modebarlayout import modebar_layout
+from beaverdam.viewer.plotly_modebarlayout import modebar_layout
 
 
 def set_ui_object_id(element_type, id=[]):

--- a/src/beaverdam/viewer/dash_view.py
+++ b/src/beaverdam/viewer/dash_view.py
@@ -15,9 +15,9 @@ from dash import (
     html,
 )
 
-from . import builduielements_dash
-from .colours import Colours
-from .view import View
+from beaverdam.viewer import builduielements_dash
+from beaverdam.viewer.colours import Colours
+from beaverdam.viewer.view import View
 
 
 class DashView(View):

--- a/src/beaverdam/viewer/plotly_theme.py
+++ b/src/beaverdam/viewer/plotly_theme.py
@@ -27,7 +27,7 @@
 import plotly.graph_objects as go
 import plotly.io as pio
 
-from .colours import Colours
+from beaverdam.viewer.colours import Colours
 
 # General figure properties
 pio.templates["main"] = go.layout.Template(

--- a/src/beaverdam/viewer/presenter.py
+++ b/src/beaverdam/viewer/presenter.py
@@ -1,6 +1,6 @@
 """Prepare data for visualization."""
 
-from .uielement import DataFigure, DataTable, FilterChecklist, SelectedCriteria
+from beaverdam.viewer.uielement import DataFigure, DataTable, FilterChecklist, SelectedCriteria
 
 
 class Presenter:

--- a/src/beaverdam/viewer/run_ui.py
+++ b/src/beaverdam/viewer/run_ui.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 from beaverdam._core import ConfigParser, Core
 
-from .controller import Controller
-from .dash_view import DashView
-from .presenter import Presenter
+from beaverdam.viewer.controller import Controller
+from beaverdam.viewer.dash_view import DashView
+from beaverdam.viewer.presenter import Presenter
 
 ## INPUTS
 


### PR DESCRIPTION
This allows modules to be run as scripts, so that they can be included in other code and/or debugged more easily.