### PR TITLE
Allow files to be run as scripts for debugging

### DIFF
--- a/src/beaverdam/builder/build_database.py
+++ b/src/beaverdam/builder/build_database.py
@@ -10,15 +10,6 @@ from beaverdam._core import ConfigParser, MongoDbDatabase
 from beaverdam.builder.metadatafiletools import load_metadata
 from beaverdam.builder.pluralize import pluralize
 
-## INPUTS
-
-# Name of configuration file
-cfg_file_name = Path("config.toml")
-db_extension = ".json"
-
-
-## CODE
-
 
 class BeaverDB:
     """Create or update a database from a directory of metadata files."""
@@ -160,3 +151,15 @@ def build_database(cfg_file_name):
     cfg_file_name = Path(cfg_file_name)
     user_database = BeaverDB(cfg_file_name)
     user_database.update_database()
+
+if __name__ == "__main__":
+    # Edit the name and location of the config file appropriately.
+    #
+    # An alternative approach is to define cfg_file_name in the configurations section
+    # of launch.json if you are using VSCode, e.g.:
+    #    env: {"cfg_file_name": "config_countries.toml"}
+    # Then access this variable here using e.g.:
+    #    import os
+    #    cfg_file_name = os.environ.get("cfg_file_name")
+    cfg_file_name = "config_countries.toml"
+    build_database(cfg_file_name)

--- a/src/beaverdam/builder/build_database.py
+++ b/src/beaverdam/builder/build_database.py
@@ -153,7 +153,8 @@ def build_database(cfg_file_name):
     user_database.update_database()
 
 if __name__ == "__main__":
-    # Edit the name and location of the config file appropriately.
+    # Edit the name and RELATIVE (to this file) location of the config file
+    # appropriately.
     #
     # An alternative approach is to define cfg_file_name in the configurations section
     # of launch.json if you are using VSCode, e.g.:
@@ -161,5 +162,6 @@ if __name__ == "__main__":
     # Then access this variable here using e.g.:
     #    import os
     #    cfg_file_name = os.environ.get("cfg_file_name")
-    cfg_file_name = "config_countries.toml"
+    cfg_file_name = Path(__file__).parents[3] / "config_countries.toml"
+    # Build the database
     build_database(cfg_file_name)

--- a/src/beaverdam/viewer/run_ui.py
+++ b/src/beaverdam/viewer/run_ui.py
@@ -7,11 +7,6 @@ from beaverdam.viewer.controller import Controller
 from beaverdam.viewer.dash_view import DashView
 from beaverdam.viewer.presenter import Presenter
 
-## INPUTS
-
-# Name of configuration file
-cfg_file_name = Path("config.toml")
-
 
 class BeaverUI:
     """Define and configure modules to be included in the user interface."""
@@ -53,3 +48,15 @@ def run_ui(cfg_file_name):
     cfg_file_name = Path(cfg_file_name)
     user_interface = BeaverUI(cfg_file_name)
     user_interface.run()
+
+if __name__ == "__main__":
+    # Edit the name and location of the config file appropriately.
+    #
+    # An alternative approach is to define cfg_file_name in the configurations section
+    # of launch.json if you are using VSCode, e.g.:
+    #    env: {"cfg_file_name": "config_countries.toml"}
+    # Then access this variable here using e.g.:
+    #    import os
+    #    cfg_file_name = os.environ.get("cfg_file_name")
+    cfg_file_name = "config_countries.toml"
+    run_ui(cfg_file_name)

--- a/src/beaverdam/viewer/run_ui.py
+++ b/src/beaverdam/viewer/run_ui.py
@@ -50,7 +50,8 @@ def run_ui(cfg_file_name):
     user_interface.run()
 
 if __name__ == "__main__":
-    # Edit the name and location of the config file appropriately.
+    # Edit the name and RELATIVE (to this file) location of the config file
+    # appropriately.
     #
     # An alternative approach is to define cfg_file_name in the configurations section
     # of launch.json if you are using VSCode, e.g.:
@@ -58,5 +59,6 @@ if __name__ == "__main__":
     # Then access this variable here using e.g.:
     #    import os
     #    cfg_file_name = os.environ.get("cfg_file_name")
-    cfg_file_name = "config_countries.toml"
+    cfg_file_name = Path(__file__).parents[3] / "config_countries.toml"
+    # Generate the UI
     run_ui(cfg_file_name)


### PR DESCRIPTION
In VSCode, debugging with breakpoints is very useful.  But this is only possible (as far as I can figure out) when running a .py file as a script using F5 or the "Run and debug" button.  This pull request adds functionality to the files controlling the creation of the database and user interface (i.e. the main entry points into Beaverdam), so that they can be run as scripts.

This pull request resolves Issue #6 .